### PR TITLE
Fixing redirects and sidebar highlighting

### DIFF
--- a/content/kotsadm/editing-ingress.md
+++ b/content/kotsadm/editing-ingress.md
@@ -1,7 +1,0 @@
----
-date: 2019-10-09
-linktitle: "Editing the kotsadm Ingress"
-title: Admin Console Ingress
-weight: 10060
-draft: true
----

--- a/content/kotsadm/kotsadm-architecture.md
+++ b/content/kotsadm/kotsadm-architecture.md
@@ -1,7 +1,0 @@
----
-date: 2019-10-09
-linktitle: "A description of the kotsadm architecture"
-title: kotsadm Architecture
-weight: 10040
-draft: true
----

--- a/content/kotsadm/merging-multiple-apps.md
+++ b/content/kotsadm/merging-multiple-apps.md
@@ -1,7 +1,0 @@
----
-date: 2019-10-09
-linktitle: "Deploying to multiple environments"
-title: Multiple Environments
-weight: 10030
-draft: true
----

--- a/content/kotsadm/multiple-downstreams.md
+++ b/content/kotsadm/multiple-downstreams.md
@@ -1,7 +1,0 @@
----
-date: 2019-10-09
-linktitle: "Merging multiple applications into a single Admin Console"
-title: Merging Multiple Applications
-weight: 10080
-draft: true
----

--- a/content/kotsadm/registries/self-hosted-registry.md
+++ b/content/kotsadm/registries/self-hosted-registry.md
@@ -4,8 +4,6 @@ linktitle: "Using self-hosted image registry"
 title: Self-Hosted Image Registry
 description: "Kots can be used to download and prepare an application to be installed onto a secured, airgapped Kubernetes cluster. When doing this, there are a few additional steps and configuration needed."
 weight: 10010
-aliases: 
-  - /kotsadm/registries/
 ---
 
 Kots can be used to download and prepare an application to be installed onto a secured, airgapped Kubernetes cluster. When doing this, there are a few additional steps and configuration needed.

--- a/content/kotsadm/registries/self-hosted-registry.md
+++ b/content/kotsadm/registries/self-hosted-registry.md
@@ -32,7 +32,7 @@ For this example, we will assume that the application is available at replicated
 
 - The workstation cannot access the cluster
 - The workstation CAN access the image registry
-- The image registry is at https://registry.somebigbank.com
+- The image registry is at `https://registry.somebigbank.com`
 - The workstation already is logged in to the registry
 - The registry namespace “application-name” can be used for this application
 
@@ -41,7 +41,7 @@ kubectl kots pull replicated://application-name \
   --license-file ~/application-license-yaml \
   --rewrite-images \
   --image-namespace application-name \
-  --registry-endpoint https://registry.somebigbank.com
+  --registry-endpoint `https://registry.somebigbank.com`
 ```
 
 This command will:

--- a/content/kotsadm/zerotrust-management.md
+++ b/content/kotsadm/zerotrust-management.md
@@ -1,7 +1,0 @@
----
-date: 2019-10-09
-linktitle: "ZeroTrust management of Kotsadm applications"
-title: Managing Using ZeroTrust
-weight: 10070
-draft: true
----

--- a/content/reference/_index.md
+++ b/content/reference/_index.md
@@ -3,6 +3,6 @@ date: "2019-09-30T00:00:00Z"
 lastmod: "2019-09-30T00:00:00Z"
 title: "Kots.io Reference"
 description: "Kots.io Reference."
-redirect: "/reference/kubernetes-installers/kurl"
+redirect: "/reference/v1beta1"
 weight: "9"
 ---

--- a/content/reference/v1beta1/_index.md
+++ b/content/reference/v1beta1/_index.md
@@ -3,8 +3,6 @@ date: "2020-01-02"
 lastmod: "2020-01-02"
 title: "KOTS Custom Resources"
 weight: "1"
-aliases: 
-  - /v1beta1/
 ---
 
 A KOTS application can include several recommended, but optional, custom resources. These custom resources are packaged as part of the KOTS application, but are not deployed to the cluster. The custom resources defined here are included to control the KOTS application experience, but are consumed by KOTS, the Admin Console (kotsadm) or by other kubectl plugins.

--- a/content/vendor/airgap.md
+++ b/content/vendor/airgap.md
@@ -1,7 +1,0 @@
----
-date: 2019-10-09
-linktitle: "Airgap Builds"
-title: Creating Airgap Bundles
-weight: 20050
-draft: true
----

--- a/content/vendor/licenses-and-release-channels.md
+++ b/content/vendor/licenses-and-release-channels.md
@@ -1,7 +1,0 @@
----
-date: 2019-10-09
-linktitle: "Licenses and Release Channels"
-title: Licenses and Release Channels
-weight: 20030
-draft: true
----

--- a/content/vendor/promote-releases-cli.md
+++ b/content/vendor/promote-releases-cli.md
@@ -1,7 +1,0 @@
----
-date: 2019-10-09
-linktitle: "Using the CLI to promote releases"
-title: Promote Releases via CLI
-weight: 20090
-draft: true
----

--- a/themes/hugo-whisper-theme/layouts/_default/list.html
+++ b/themes/hugo-whisper-theme/layouts/_default/list.html
@@ -14,7 +14,7 @@
 {{else}}
 <h1 class="title">{{ .Title }}</h1>
 <div class="content">
-  {{ .Content }}sdf
+  {{ .Content }}
 </div>
 {{ end }}
 

--- a/themes/hugo-whisper-theme/layouts/_default/list.html
+++ b/themes/hugo-whisper-theme/layouts/_default/list.html
@@ -1,11 +1,21 @@
 {{ define "header_css" }}{{ end }}
 {{ define "body_classes" }}page-default-list{{ end }}
 {{ define "header_classes" }}{{ end }}
-
 {{ define "main" }}
+{{ if isset .Params "redirect" }}
+<!DOCTYPE html><html>
+    <head>
+        <title>{{ .Params.redirect | relURL }}</title>
+        <link rel="canonical" href="{{ .Params.redirect | relURL }}"/>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <meta http-equiv="refresh" content="0; url={{ .Params.redirect }}" />
+    </head>
+</html>
+{{else}}
 <h1 class="title">{{ .Title }}</h1>
 <div class="content">
-  {{ .Content }}
+  {{ .Content }}sdf
 </div>
+{{ end }}
 
 {{ end }}

--- a/themes/hugo-whisper-theme/layouts/partials/sidebar.html
+++ b/themes/hugo-whisper-theme/layouts/partials/sidebar.html
@@ -14,7 +14,7 @@
   <ul>
     {{ range .FirstSection.Pages }}
       {{ if .IsPage }}
-        <li class="{{ if eq .Title $currentNode.Title }}active{{ end }}">
+        <li class="{{ if eq .File $currentNode.File }}active{{ end }}">
           <a href="{{ .Permalink | relURL }}">
             {{ if .Params.linktitle }}
               {{ .Params.linktitle }}
@@ -24,7 +24,7 @@
           </a>
         </li>
       {{ else }}
-        <li class="is-parent {{ if eq .Title $currentNode.Title }}active{{ end }}">
+        <li class="is-parent {{ if eq .File.Dir $currentNode.File.Dir }}active{{ end }}">
           <a href="{{ or .Params.redirect .Permalink | relURL }}">
             {{ if .Params.linktitle }}
               {{ .Params.linktitle }}
@@ -35,7 +35,7 @@
         </li>
         {{ if $currentNode.IsDescendant . }}
           {{ range .Pages }}
-            <li class="is-descendant {{ if eq .Title $currentNode.Title }}active{{ end }}">
+            <li class="is-descendant {{ if eq .File $currentNode.File }}active{{ end }}">
               <a href="{{ .Permalink | relURL }}">
                 {{ if .Params.linktitle }}
                   {{ .Params.linktitle }}	


### PR DESCRIPTION
The "redirect" argument was used in the _index.md files to indicate what should happen when you click the sidebar link for a section (e.g., so that clicking "Packaging an App" would take user to /vendor/packaging/packaging-an-app instead of the blank /vendor/packaging). 

This is a problem because having an _index.md file prevents using aliasing. That is, there was no way to then create an alias for /vendor/packaging because there was a direct page there. 

To fix this, I modified the list.html layout to do the exact same thing than an alias does (a meta redirect/refresh) when a "redirect" parameter exists. This way, we don't need to alias /vendor/packaging -- it just behaves properly. Moreover, we also then have proper sidebar highlighting. 

Also noticed that the sidebar highlighting itself was broken because it was working against the Title field (which sometimes is different than the title of the page). Made this more robust (and working) by using the URL of the page instead. 

Then removed some empty draft files. 