### PR TITLE
Correcting a lot of problems on config.md page

### DIFF
--- a/content/reference/v1beta1/config.md
+++ b/content/reference/v1beta1/config.md
@@ -46,125 +46,121 @@ and `type` properties. Specific item types can including new types.
 ### `bool`
 The `bool` input type should use a "0" or "1" to set the value
 ```yaml
-- name: toggles
-  items:
-  - name: http_enabled
-    title: HTTP Enabled
-    help_text: When enabled we will listen to http
-    type: bool
-    default: "0"
+    - name: toggles
+      items:
+      - name: http_enabled
+        title: HTTP Enabled
+        help_text: When enabled we will listen to http
+        type: bool
+        default: "0"
 ```
 
 ### `label`
 The `label` type allows you to display an input label.
 ```yaml
-- name: Email
-  items:
-  - name: email-address
-    title: Email Address
-    type: text
-  - name: description
-    type: label
-    title: "Note: The system will send you an email every hour."
+    - name: Email
+      items:
+      - name: email-address
+        title: Email Address
+        type: text
+      - name: description
+        type: label
+        title: "Note: The system will send you an email every hour."
 ```
 
 ### `heading`
-The `heading` type allows you to display a group heading as a subelement within a group. This is useful when you would like to group items all in one config group but would like to separate the items visually, for instance when using a config group test proc.
+The `heading` type allows you to display a group heading as a subelement within a group. This is useful when you would like to group items all in one config group but would like to separate the items visually, for instance when using a config group test proc. **Currently, the `heading` item type is not supported**
 ```yaml
-- name: ldap_settings
-  title: LDAP Server Settings
-  test_proc:
-    display_name: Test Credentials
-    command: ldap_auth
-    arg_fields:
-    - ...
-  items:
-  ...
-  - name: ldap_schema
-    type: heading
-    title: LDAP schema
-  ...
+    - name: ldap_settings
+      title: LDAP Server Settings
+      test_proc:
+        display_name: Test Credentials
+        command: ldap_auth
+        arg_fields:
+        - ...
+      items:
+      ...
+      - name: ldap_schema
+        type: heading
+        title: LDAP schema
+      ...
 ```
 
 ### `select`
 Types `select_one` and `select_many` are special cases. These types must have nested items
 that act as options. These types will be displayed as radio buttons (`select_one`) or
-checkboxes (`select_many`) in the admin console.
+checkboxes (`select_many`) in the admin console. **Currently, the `select_many` item type is not supported**
 
 At this time these two control types do not support the `title` field.
 
 ```yaml
-- name: inputs
-  title: Inputs
-  description: ""
-  items:
-  - name: logstash_input_enabled
-    default: ""
-    type: select_many
-    items:
-    - name: logstash_input_file_enabled
-      title: File
-      default: "0"
-    - name: logstash_input_lumberjack_enabled
-      title: Lumberjack
-      default: "0"
-- name: authentication
-  title: Authentication
-  description: ""
-  items:
-  - name: authentication_type
-    default: authentication_type_anonymous
-    type: select_one
-    items:
-    - name: authentication_type_anonymous
-      title: Anonymous
-    - name: authentication_type_password
-      title: Password
+    - name: inputs
+      title: Inputs
+      description: ""
+      items:
+      - name: logstash_input_enabled
+        default: ""
+        type: select_many
+        items:
+        - name: logstash_input_file_enabled
+          title: File
+          default: "0"
+        - name: logstash_input_lumberjack_enabled
+          title: Lumberjack
+          default: "0"
+    - name: authentication
+      title: Authentication
+      description: ""
+      items:
+      - name: authentication_type
+        default: authentication_type_anonymous
+        type: select_one
+        items:
+        - name: authentication_type_anonymous
+          title: Anonymous
+        - name: authentication_type_password
+          title: Password
 ```
 
 ### `textarea`
 A `textarea` can specify a `props` that will map into the HTML element directly. Examples of available properties are `rows`, `cols` and `wrap`. See https://www.w3schools.com/tags/tag_textarea.asp for reference.
 
 ```yaml
-- name: custom_key
-  title: Set your secret key for your app
-  description: Paste in your Custom Key
-  items:
-  - name: key
-    title: Key
-    type: textarea
-    props:
-      rows: 8
-  - name: hostname
-    title: Hostname
-    type: text
+    - name: custom_key
+      title: Set your secret key for your app
+      description: Paste in your Custom Key
+      items:
+      - name: key
+        title: Key
+        type: textarea
+        props:
+          rows: 8
+      - name: hostname
+        title: Hostname
+        type: text
 ```
 
 ### `file`
 A `file` is a special type of form field that renders an [`<input type="file" />`](https://www.w3schools.com/tags/tag_input.asp) HTML element. It has both a value, which holds the file name, and data, the contents of the file. See the [`ConfigOptionData`](https://help.replicated.com/docs/native/packaging-an-application/template-functions/#configoptiondata) template function for examples on how to use the file contents in your application.
 
 ```yaml
-- name: certs
-  title: TLS Configuration
-  items:
-  - name: tls_private_key_file
-    title: Private Key
-    when: use_tls=tls_custom
-    value: Use self-signed certificate
-    data_cmd:
-      name: ssl_cert
-      value_at: 0
-    type: file
-    affix: left
-  - name: tls_certificate_file
-    title: Certificate
-    when: use_tls=tls_custom
-    value: Use self-signed certificate
-    data_cmd:
-      name: ssl_cert
-      value_at: 1
-    type: file
-    affix: right
+    - name: certs
+      title: TLS Configuration
+      items:
+      - name: tls_private_key_file
+        title: Private Key
+        value: Use self-signed certificate
+        data_cmd:
+          name: ssl_cert
+          value_at: 0
+        type: file
+      - name: tls_certificate_file
+        title: Certificate
+        value: Use self-signed certificate
+        data_cmd:
+          name: ssl_cert
+          value_at: 1
+        type: file
 ```
 
 ## Properties
@@ -183,21 +179,21 @@ in the settings section of the On-Prem Console.
 *Please note that setting ```readonly:true``` will render a value generated by a command to be ephemeral.  This feature has since been deprecated and may change in the future.*
 
 ```yaml
-- name: custom_key
-  title: Set your secret key for your app
-  description: Paste in your Custom Key
-  items:
-  - name: key
-    title: Key
-    type: text
-    value: ""
-    default: change me
+    - name: custom_key
+      title: Set your secret key for your app
+      description: Paste in your Custom Key
+      items:
+      - name: key
+        title: Key
+        type: text
+        value: ""
+        default: change me
 ```
 
 ### `required`
 A required field will prevent the application from starting until it has a value.
 ```yaml
-    required: true
+        required: true
 ```
 
 ### `when`
@@ -206,42 +202,57 @@ The when value is used to denote conditional inputs that will only be visible (o
 The settings UI will update right away when a field used in a when clause is updated (no need to save) and can be used to used to show optional config sections. The equality check should match exactly without quotes.
 
 ```yaml
-- name: database_settings_group
-  items:
-  - name: db_type
-    type: select_one
-    default: embedded
-    items:
-    - name: external
-      title: External
-    - name: embedded
-      title: Embedded DB
-  - name: database_host
-    title: Database Hostname
-    type: text
-    when: db_type=external
-  - name: database_password
-    title: Database Password
-    type: password
-    when: '{{repl or (ConfigOptionEquals "db_type" "external") (ConfigOptionEquals "db_type" "embedded")}}'
+    - name: database_settings_group
+      items:
+      - name: db_type
+        type: select_one
+        default: external
+        items:
+        - name: external
+          title: External
+        - name: embedded
+          title: Embedded DB
+      - name: database_host
+        title: Database Hostname
+        type: text
+        when: '{{repl (ConfigOptionEquals "db_type" "external")}}'
+      - name: database_password
+        title: Database Password
+        type: password
+        when: '{{repl (ConfigOptionEquals "db_type" "external")}}'
 ```
 
 ### `recommended`
-An item can be recommended. This item will bear the tag "recommended" in the admin console.
+An item can be recommended. This item will bear the tag "recommended" in the admin console. **Presently only works for boolean and text field types**
 ```yaml
-    recommended: true
+    - name: toggles
+      items:
+      - name: http_enabled
+        title: HTTP Enabled
+        help_text: When enabled we will listen to http
+        type: bool
+        default: "0"
+        recommended: true
 ```
 
 ### `hidden`
 Items can be hidden. They will not be visible if hidden.
 ```yaml
-    hidden: true
+        - name: secret_key
+          title: Secret Key
+          type: password
+          hidden: true
+          value: "{{repl RandomString 40}}"
 ```
 
 ### `readonly`
 Items can be readonly.
 ```yaml
-    readonly: true
+        - name: unique_id
+          title: Unique ID
+          type: text
+          value: "{{repl RandomString 20}}"
+          readonly: true
 ```
 
 ### `write_once`
@@ -258,7 +269,7 @@ It is recommended to avoid using `default` with `write_once` items.
 ```
 
 ### `affix`
-Items can be affixed left or right. These items will appear in the admin console on the same line.
+Items can be affixed left or right. These items will appear in the admin console on the same line. 
 ```yaml
     affix: left
 ```

--- a/content/reference/v1beta1/config.md
+++ b/content/reference/v1beta1/config.md
@@ -255,18 +255,6 @@ Items can be readonly.
           readonly: true
 ```
 
-### `write_once`
-Items with the write_once property set to true will be locked the first time they are set.
-Locked items will appear readonly in the UI and will be ignored if set with `replicatedctl` or imported from a file.
-
-Any operation that sets an item is considered a write and will cause the item to be locked. This includes setting the item value in the UI, importing the value from a file specified in `/etc/replicated.conf` with the `ImportSettingsFrom` key, setting the value with `replicatedctl`, or setting the value with `value_cmd`.
-
-If the item has a `default` it will be locked the first time the user saves settings in the admin console.
-It is recommended to avoid using `default` with `write_once` items.
-
-```yaml
-    write_once: true
-```
 
 ### `affix`
 Items can be affixed left or right. These items will appear in the admin console on the same line. 


### PR DESCRIPTION
Provided examples for bool, label, hidden, read-only
Fixed issues with `file` and `when` examples. 
Added spaces so that examples could be pasted into config.yaml
Noted which items aren't working right now: heading, select_many, recommended.