### PR TITLE
Rearranging some menu items on the vendor page to make things more clear, and to help with dashboard docs. 

### DIFF
--- a/content/reference/v1beta1/application.md
+++ b/content/reference/v1beta1/application.md
@@ -10,7 +10,7 @@ aliases:
 
 The KOTS Application custom resource enables features such as branding, release notes, port forwarding, dashboard buttons, app status indicators, and custom graphs.
 
-With ports specified, the kots CLI can establish port-forwarding, to simplify connections to the deployed application.  When [statusInformers](/vendor/dashboard/application-status/#kots-application-spec) are specified, the dashboard can provide timely feedback when the application deployment is complete and the application is ready for use. This CR is optional for KOTS applications.
+With ports specified, the kots CLI can establish port-forwarding, to simplify connections to the deployed application.  When [statusInformers](/vendor/config/application-status/#kots-application-spec) are specified, the dashboard can provide timely feedback when the application deployment is complete and the application is ready for use. This CR is optional for KOTS applications.
 
 There is some overlap between the [KOTS Application spec](/reference/v1beta1/application/) and the [Kubernetes SIG Application spec](https://github.com/kubernetes-sigs/application#application-objects).  In time, it's likely that the SIG Application spec will grow to include all the necessary metadata to support the full KOTS features.  In the meantime, enabling features (such as [dashboard buttons to the application](/vendor/dashboard/open-buttons/)) requires the use of both the KOTS Application spec and the SIG Application spec.
 

--- a/content/vendor/cli/_index.md
+++ b/content/vendor/cli/_index.md
@@ -4,5 +4,5 @@ lastmod: "2019-09-30T00:00:00Z"
 linktitle: "Vendor CLI"
 description: "Pages giving a general overview of the Kots CLI"
 redirect: "/vendor/cli/getting-started"
-weight: "1"
+weight: "4"
 ---

--- a/content/vendor/config/_index.md
+++ b/content/vendor/config/_index.md
@@ -1,9 +1,8 @@
 ---
 date: "2019-09-30T00:00:00Z"
 lastmod: "2019-09-30T00:00:00Z"
-title: "Creating A Config Screen"
+title: "Admin Console Customization"
 redirect: "/vendor/config/config-screen"
 weight: "3"
 ---
 
-The KOTS Admin Console can prompt for application settings during installation time. The syntax used is powerful and designed to build experiences that validate input.

--- a/content/vendor/config/application-status.md
+++ b/content/vendor/config/application-status.md
@@ -1,8 +1,10 @@
 ---
 date: 2019-10-09
 linktitle: "Application Status"
-title: Determining Application Status
-weight: 20020
+title: Application Status
+weight: 20011
+aliases: 
+  - /vendor/dashboard/application-status/
 ---
 
 With minimal additional to the kots.io Application YAML, it is possible to display application status on the dashboard of the Admin Console.

--- a/content/vendor/config/config-screen.md
+++ b/content/vendor/config/config-screen.md
@@ -1,7 +1,7 @@
 ---
 date: 2019-10-09
-linktitle: "Overview"
-title: Creating A Config Screen
+linktitle: "Configuration Screen"
+title: Configuration Screen
 description: "Kots applications can include a robust, custom configuration page. This is a dynamic form that can be used to prompt for, validate and generate inputs that are needed to start the application. During installation, the customer will be directed to this page after uploading a license if there are required fields. For applications that don't have any required fields, this page will be accessible from the Config tab of the Admin Console."
 weight: 20010
 ---

--- a/content/vendor/config/dashboard-buttons.md
+++ b/content/vendor/config/dashboard-buttons.md
@@ -1,9 +1,11 @@
 ---
 date: 2019-10-09
-linktitle: "Links and Buttons"
-title: Adding Buttons To The Dashboard
+linktitle: "Dashboard Buttons and Links"
+title: Dashboard Buttons and Links
 description: "When distributing an application, it’s helpful to make sure that the installer can easily verify that the application is running. Because networking and ingress is possibly handled differently in each cluster, this makes it difficult to provide a consistent URL at application packaging time, and even likely requires that the cluster operator create firewall rules before they can test the application installation."
-weight: 20010
+weight: 20014
+aliases: 
+  - /vendor/dashboard/open-buttons
 ---
 
 When distributing an application, it’s helpful to make sure that the installer can easily verify that the application is running. Because networking and ingress is possibly handled differently in each cluster, this makes it difficult to provide a consistent URL at application packaging time, and even likely requires that the cluster operator create firewall rules before they can test the application installation.

--- a/content/vendor/config/dashboard-graphs.md
+++ b/content/vendor/config/dashboard-graphs.md
@@ -1,8 +1,10 @@
 ---
 date: 2019-11-01
 linktitle: "Dashboard Graphs"
-title: Adding Dashboard Graphs
+title: Dashboard Graphs
 weight: 20030
+aliases: 
+  - /vendor/dashboard/graphs
 ---
 
 By default, when installing a Kots application into an embedded cluster, the Prometheus monitoring system will be included alongside the Kots application. This will collect valuable metrics about the cluster as well as the application and expose graphs with key metrics on the dashboard of the Admin Console. When running in an existing cluster, it is possible to configure the address of the Prometheus service in the Admin Console.

--- a/content/vendor/dashboard/_index.md
+++ b/content/vendor/dashboard/_index.md
@@ -1,10 +1,8 @@
 ---
 date: "2019-09-30T00:00:00Z"
 lastmod: "2019-09-30T00:00:00Z"
-title: "Customize the Dashboard"
-description: "Customizing the Dashboard"
-redirect: "/vendor/dashboard/open-buttons"
-weight: "4"
+description: "Dashboard Customization"
+redirect: "/vendor/config/dashboard-buttons"
+weight: "9999999"
 ---
 
-The KOTS Admin Console can be modified to include application-specific controls and settings.

--- a/content/vendor/embedded-kubernetes/_index.md
+++ b/content/vendor/embedded-kubernetes/_index.md
@@ -1,7 +1,6 @@
 ---
 date: "2019-09-30T00:00:00Z"
 lastmod: "2019-09-30T00:00:00Z"
-title: "Embedded Kubernetes"
-redirect: "/vendor/embedded-kubernetes/embedded-kubernetes"
-weight: "6"
+redirect: "/vendor/packaging/embedded-kubernetes"
+weight: "9999999"
 ---

--- a/content/vendor/entitlements/_index.md
+++ b/content/vendor/entitlements/_index.md
@@ -3,5 +3,5 @@ date: "2019-09-30T00:00:00Z"
 lastmod: "2019-09-30T00:00:00Z"
 title: "Licenses and Entitlements"
 redirect: "/vendor/entitlements/custom-entitlements/"
-weight: "5"
+weight: "2"
 ---

--- a/content/vendor/helm/_index.md
+++ b/content/vendor/helm/_index.md
@@ -2,7 +2,6 @@
 date: "2019-12-27T00:00:00Z"
 lastmod: "2019-12-27T00:00:00Z"
 title: "Helm Charts"
-weight: "3"
+weight: "4"
 redirect: "/vendor/helm/using-helm-charts/"
-hideFromList: true
 ---

--- a/content/vendor/packaging/_index.md
+++ b/content/vendor/packaging/_index.md
@@ -1,7 +1,7 @@
 ---
 date: "2019-09-30T00:00:00Z"
 lastmod: "2019-09-30T00:00:00Z"
-title: "Packaging KOTS with Vendor"
+title: "Packaging KOTS Applications"
 redirect: "/vendor/packaging/packaging-an-app"
 weight: "1"
 ---

--- a/content/vendor/packaging/embedded-kubernetes.md
+++ b/content/vendor/packaging/embedded-kubernetes.md
@@ -1,9 +1,11 @@
 ---
 date: 2019-10-23
-linktitle: "Overview"
+linktitle: "Embedded Kubernetes"
 title: Embedded Kubernetes
 description: "A KOTS application can be deployed to an existing cluster or the installer can provision a new cluster with the application."
 weight: 20090
+aliases: 
+  - /vendor/embedded-kubernetes/embedded-kubernetes
 ---
 
 A KOTS application can be deployed to an existing cluster or the installer can provision a new cluster with the application.

--- a/content/vendor/packaging/packaging-an-app.md
+++ b/content/vendor/packaging/packaging-an-app.md
@@ -1,7 +1,7 @@
 ---
 date: 2019-10-23
 linktitle: "Overview"
-title: Packaging KOTS with Vendor
+title: Packaging KOTS Applications
 weight: 10
 ---
 


### PR DESCRIPTION
The key is the distinction between "Admin Console Configuration" and "Application Configuration," which will be more and more useful as we add more content. 

Aliases were verified. 

No content updates, just a bit of reorg. 
![image](https://user-images.githubusercontent.com/8466736/73977336-065ebb80-48df-11ea-9c2e-5212573e004c.png)
