### PR TITLE
Hidden vs. Readonly Properties

### DIFF
--- a/content/kotsadm/installing/system-requirements.md
+++ b/content/kotsadm/installing/system-requirements.md
@@ -21,6 +21,8 @@ This includes support against all patch releases of the corrersponding Kubernete
 | 1.13 | 2020-02-27 | 1.17, 1.16, and 1.15 |
 | 1.14 | 2020-03-31 | 1.17, 1.16, and 1.15 |
 | 1.15 | 2020-05-01 | 1.18, 1.17, and 1.16 |
+| 1.16 | 2020-06-01 | 1.18, 1.17, and 1.16 |
+| 1.17 | 2020-07-14 | 1.18, 1.17, and 1.16 |
 
 ## Existing Cluster Installation Requirements
 

--- a/content/reference/template-functions/static-context.md
+++ b/content/reference/template-functions/static-context.md
@@ -150,7 +150,6 @@ Returns a random string with the desired length and charset.
 Provided charsets must be Perl formatted and match individual characters.
 If no charset is provided, `[_A-Za-z0-9]` will be used.
 
-Each time that this function is called, it will return a different value.
 ```yaml
 '{{repl RandomString 64}}'
 ```
@@ -158,6 +157,13 @@ Or for a total of 64 `a`s and `b`s:
 ```yaml
 '{{repl RandomString 64 "[ab]" }}'
 ```
+
+Each time that this function is called, the behavior changes based on the [hidden](/reference/v1beta1/config/#hidden) and [readonly](/reference/v1beta1/config/#readonly) properties.
+
+- To generate `RandomString` value that is **persistent** between Config changes, use it in conjuction with `hidden` property set to `true`. The `value` is not shown in HTML, hence it cannot be modified.
+- To generate `RandomString` value that is **ephemeral** between Config changes, use it in conjuction with `readonly` property set to `true`. The `value` is shown in HTML but the it cannot be modified.
+- If `hidden` and `readonly` are not set or set to `false`, the `value` is **persistent** between Config changes but it can also be modified in HTML.
+- If both `hidden` and `readonly` are set to `true`, the `value` is not shown in HTML but it is **ephemeral** between Config changes and not modifiable.
 
 ## Add
 ```go

--- a/content/reference/v1beta1/config.md
+++ b/content/reference/v1beta1/config.md
@@ -256,6 +256,6 @@ This is similar to `description` but for `items`. This property can show a helpf
       items:
       - name: http_enabled
         title: HTTP Enabled
-        help_text: When enabled we will listen to http
+        help_text: Check to enable the HTTP listener
         type: bool
 ```

--- a/content/reference/v1beta1/config.md
+++ b/content/reference/v1beta1/config.md
@@ -250,7 +250,7 @@ Items can be affixed left or right. These items will appear in the admin console
 ```
 
 ### `help_text`
-This is similar to `description` but for `items`. This property can show a helpful message below `title`. **[Markdown](https://guides.github.com/features/mastering-markdown/) syntax is supported.**
+This is similar to `description` but for `items`. This property can show a helpful message below `title`. [Markdown](https://guides.github.com/features/mastering-markdown/) syntax is supported.
 ```yaml
     - name: toggles
       items:

--- a/content/reference/v1beta1/config.md
+++ b/content/reference/v1beta1/config.md
@@ -24,6 +24,8 @@ spec:
     description: Configure application authentication below.
 ```
 
+**Note:** `description` is only supported in `groups`, see `help_text` property for `items`. [Markdown](https://guides.github.com/features/mastering-markdown/) syntax is supported in this property.
+
 ## Items
 
 Items map to input fields and belong to a single group. All items should have `name`, `title`
@@ -49,7 +51,6 @@ The `bool` input type should use a "0" or "1" to set the value
       items:
       - name: http_enabled
         title: HTTP Enabled
-        help_text: When enabled we will listen to http
         type: bool
         default: "0"
 ```
@@ -209,7 +210,6 @@ An item can be recommended. This item will bear the tag "recommended" in the adm
       items:
       - name: http_enabled
         title: HTTP Enabled
-        help_text: When enabled we will listen to http
         type: bool
         default: "0"
         recommended: true
@@ -247,4 +247,15 @@ When used in conjunction with [RandomString](/reference/template-functions/stati
 Items can be affixed left or right. These items will appear in the admin console on the same line.
 ```yaml
     affix: left
+```
+
+### `help_text`
+This is similar to `description` but for `items`. This property can show a helpful message below `title`. **[Markdown](https://guides.github.com/features/mastering-markdown/) syntax is supported.**
+```yaml
+    - name: toggles
+      items:
+      - name: http_enabled
+        title: HTTP Enabled
+        help_text: When enabled we will listen to http
+        type: bool
 ```

--- a/content/reference/v1beta1/config.md
+++ b/content/reference/v1beta1/config.md
@@ -225,7 +225,7 @@ Items can be hidden. They will not be visible if hidden.
           value: "{{repl RandomString 40}}"
 ```
 
-When used in conjunction with [RandomString](/reference/template-functions/static-context/#randomstring)
+When used in conjunction with a function that generates a value, for example [RandomString](/reference/template-functions/static-context/#randomstring)
 - If set to `true`, the `value` is **persistent** between Config changes but it **cannot** be modified because its not visible in HTML.
 - If not set or set to `false`, the `value` is **persistent** between Config changes. It **can** be modified because it is visible in HTML.
 
@@ -239,7 +239,7 @@ Items can be readonly.
           readonly: true
 ```
 
-When used in conjunction with [RandomString](/reference/template-functions/static-context/#randomstring)
+When used in conjunction with a function that generates value, for example [RandomString](/reference/template-functions/static-context/#randomstring)
 - If set to `true`, the `value` is **ephemeral** between Config changes. It **cannot** be modified because it is greyed out in HTML.
 - If not set or set to `false`, the `value` is **persistent** between Config changes. It **can** be modified because its not greyed out in HTML.
 

--- a/content/reference/v1beta1/config.md
+++ b/content/reference/v1beta1/config.md
@@ -225,6 +225,10 @@ Items can be hidden. They will not be visible if hidden.
           value: "{{repl RandomString 40}}"
 ```
 
+When used in conjunction with [RandomString](/reference/template-functions/static-context/#randomstring)
+- If set to `true`, the `value` is **persistent** between Config changes but it **cannot** be modified because its not visible in HTML.
+- If not set or set to `false`, the `value` is **persistent** between Config changes. It **can** be modified because it is visible in HTML.
+
 ### `readonly`
 Items can be readonly.
 ```yaml
@@ -235,6 +239,9 @@ Items can be readonly.
           readonly: true
 ```
 
+When used in conjunction with [RandomString](/reference/template-functions/static-context/#randomstring)
+- If set to `true`, the `value` is **ephemeral** between Config changes. It **cannot** be modified because it is greyed out in HTML.
+- If not set or set to `false`, the `value` is **persistent** between Config changes. It **can** be modified because its not greyed out in HTML.
 
 ### `affix`
 Items can be affixed left or right. These items will appear in the admin console on the same line.


### PR DESCRIPTION
- Document how `RandomString` behaves based on `hidden` and `readonly` fields.
-  `help_text` docs were missing and clarified usage of `description`.
    - Also added a note that both support Markdown syntax.
- Updated KOTS-K8s compatibility matrix.