### PR TITLE
Fixing wording for issue with encryption and `kots install`

### DIFF
--- a/content/release-notes/1.18.0.md
+++ b/content/release-notes/1.18.0.md
@@ -46,7 +46,7 @@ kubernetes: "1.16, 1.17, and 1.18"
 * Fixed a bug where syncing license would prevent Admin Console from fetching application updates when an invalid release is present in version history.
 * Fixed a bug where images from [`Pod`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core) objects were not included in airgap builds and image URLs were not re-written to use private registries. This affected pods that were not wrapped in Deployments, Statefulsets or other objects.
 * Fixed various bugs related to installing KOTS into existing clusters that require [HTTP_PROXY support](/kotsadm/installing/online-install#proxies).
-* Fixed a bug where [`kots install ... --config <filename>`](https://kots.io/kots-cli/install/) does not encrypt valuePlaintext password fields. This prevents automated installs for applications with password type fields on the config screen.
+* Fixed a bug where [`kots install ... --config <filename>`](https://kots.io/kots-cli/install/) ignored valuePlaintext password fields. This prevents automated installs for applications with password type fields on the config screen.
 * Omit empty hostname from [kotsadm-tls secret](https://kots.io/vendor/packaging/using-tls-certs/#verify-tls-secret) in order to resolve compatibility issues with Istio.
 * Save button on the Config screen will now surface errors if the API call does not return a valid response.
 * Fixed a bug that caused the deployed application to not be fully removed from the cluster before snapshot restore started, causing snapshot restore warnings.

--- a/content/release-notes/1.18.0.md
+++ b/content/release-notes/1.18.0.md
@@ -46,7 +46,7 @@ kubernetes: "1.16, 1.17, and 1.18"
 * Fixed a bug where syncing license would prevent Admin Console from fetching application updates when an invalid release is present in version history.
 * Fixed a bug where images from [`Pod`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core) objects were not included in airgap builds and image URLs were not re-written to use private registries. This affected pods that were not wrapped in Deployments, Statefulsets or other objects.
 * Fixed various bugs related to installing KOTS into existing clusters that require [HTTP_PROXY support](/kotsadm/installing/online-install#proxies).
-* Fixed a bug that caused [`kots install ... --config <filename>`](https://kots.io/kots-cli/install/) command ignore `valuePlaintext` in password fields in the supplied config file.
+* Fixed a bug where [`kots install ... --config <filename>`](https://kots.io/kots-cli/install/) does not encrypt valuePlaintext password fields. This prevents automated installs for applications with password type fields on the config screen.
 * Omit empty hostname from [kotsadm-tls secret](https://kots.io/vendor/packaging/using-tls-certs/#verify-tls-secret) in order to resolve compatibility issues with Istio.
 * Save button on the Config screen will now surface errors if the API call does not return a valid response.
 * Fixed a bug that caused the deployed application to not be fully removed from the cluster before snapshot restore started, causing snapshot restore warnings.

--- a/content/release-notes/1.18.0.md
+++ b/content/release-notes/1.18.0.md
@@ -46,7 +46,7 @@ kubernetes: "1.16, 1.17, and 1.18"
 * Fixed a bug where syncing license would prevent Admin Console from fetching application updates when an invalid release is present in version history.
 * Fixed a bug where images from [`Pod`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core) objects were not included in airgap builds and image URLs were not re-written to use private registries. This affected pods that were not wrapped in Deployments, Statefulsets or other objects.
 * Fixed various bugs related to installing KOTS into existing clusters that require [HTTP_PROXY support](/kotsadm/installing/online-install#proxies).
-* Fixed a bug where [`kots install ... --config <filename>`](https://kots.io/kots-cli/install/) ignored valuePlaintext password fields. This prevents automated installs for applications with password type fields on the config screen.
+* Fixed a bug that caused the [`kots install ... --config <filename>`](https://kots.io/kots-cli/install/) command to ignore `valuePlaintext` password fields. This prevented automated installations for applications with password type fields on the config screen.
 * Omit empty hostname from [kotsadm-tls secret](https://kots.io/vendor/packaging/using-tls-certs/#verify-tls-secret) in order to resolve compatibility issues with Istio.
 * Save button on the Config screen will now surface errors if the API call does not return a valid response.
 * Fixed a bug that caused the deployed application to not be fully removed from the cluster before snapshot restore started, causing snapshot restore warnings.


### PR DESCRIPTION
Was previously: 

> Fixed a bug that caused kots install ... --config <filename> command ignore valuePlaintext in password fields in the supplied config file.

Changed to fix the grammar and to make it clear what the negative impact is