### PR TITLE
Add note to LicenseFieldValue about allowed vals

### DIFF
--- a/content/reference/template-functions/license-context.md
+++ b/content/reference/template-functions/license-context.md
@@ -15,6 +15,20 @@ LicenseFieldValue returns the value of the entitlement with the provided name.
 '{{repl LicenseFieldValue "numSeats" }}'
 ```
 
+In addition to custom license fields, `LicenseFieldValue` also accepts the following values:
+
+- `appSlug`
+- `channelName`
+- `customerName`
+- `endpoint`
+- `expires_at`
+- `isAirgapSupported`
+- `isGitOpsSupported`
+- `licenseID` or `licenseId`
+- `licenseSequence`
+- `licenseType`
+- `signature`
+
 ## LicenseDockerCfg
 ```go
 func LicenseDockerCfg() string


### PR DESCRIPTION
Had to dig through source of the template function as well as the REST API to figure out allowed values, figured I'd save others work by documenting them.