### PR TITLE
a few small changes

### DIFF
--- a/content/vendor/guides/cli-quickstart.md
+++ b/content/vendor/guides/cli-quickstart.md
@@ -22,7 +22,7 @@ In this guide we'll walk through the following steps:
 
 ### 1. Install CLI
 
-To start, you'll want to install the `replicated` CLI. 
+To start, you'll want to install the `replicated` CLI.
 You can install with [homebrew](https://brew.sh) or grab the latest Linux or macOS version from [the replicatedhq/replicated releases page](https://github.com/replicatedhq/replicated/releases).
 
 ```shell script
@@ -165,26 +165,26 @@ replicated release create --auto
 You'll see output similar to the following:
 
 ```text
-    • Reading Environment ✓  
-  
+    • Reading Environment ✓
+
   Prepared to create release with defaults:
-  
+
       yaml-dir        "./manifests"
       promote         "Unstable"
       version         "Unstable-ba710e5"
       release-notes   "CLI release of master triggered by dex [SHA: ba710e5] [28 Sep 20 09:15 CDT]"
       ensure-channel  true
-  
-  Create with these properties? [Y/n] 
+
+  Create with these properties? [Y/n]
 ```
 
 you can confirm the prompt by pressing Enter/Return. You'll see the release created and promoted:
 
 ```text
-  • Reading manifests from ./manifests ✓  
-  • Creating Release ✓  
+  • Reading manifests from ./manifests ✓
+  • Creating Release ✓
     • SEQUENCE: 1
-  • Promoting ✓  
+  • Promoting ✓
     • Channel VEr0nhJBBUdaWpPvOIK-SOryKZEwa3Mg successfully set to release 1
 ```
 
@@ -364,7 +364,7 @@ Next, you'll be asked for a password -- you'll want to grab the password from th
 
 ![Log In](/images/guides/kots/admin-console-login.png)
 
-Until this point, this server is just running Docker, Kubernetes, and the kotsadm containers. 
+Until this point, this server is just running Docker, Kubernetes, and the kotsadm containers.
 The next step is to upload a license file so KOTS can pull containers and run your application.
 Click the Upload button and select your `.yaml` file to continue, or drag and drop the license file from your desktop.
 
@@ -406,7 +406,8 @@ Next, we'll walk through creating and delivering an update to the application we
 ### 9. Iterating
 
 From our local repo, we can update the nginx deployment to test a simple update to the application.
-We'll add a line to `deployment.yaml`, right after `spec:`. The line to add is
+We'll add a line to `deployment.yaml`, right after `spec:`.
+The line to add is
 
 ```yaml
   replicas: 2

--- a/content/vendor/guides/existing-cluster.md
+++ b/content/vendor/guides/existing-cluster.md
@@ -5,7 +5,7 @@ title: "Existing Cluster"
 weight: "1003"
 ---
 
-The KOTS Existing Cluster Guide is one of our simplest guides. 
+The KOTS Existing Cluster Guide is one of our simplest guides.
 We'll get running quickly with a simple Nginx application on an existing cluster in GKE (or another cluster you have handy).
 
 It is broken into four sections:
@@ -17,49 +17,49 @@ It is broken into four sections:
 
 ## Creating a Release
 
-When getting started with the KOTS platform, the [Vendor Portal](https://vendor.replicated.com) will be the place you spend a lot of time. 
-This guide is designed to help you get familiar with the concepts and ideas that are important to successfully deploy your application with KOTS. 
+When getting started with the KOTS platform, the [Vendor Portal](https://vendor.replicated.com) will be the place you spend a lot of time.
+This guide is designed to help you get familiar with the concepts and ideas that are important to successfully deploy your application with KOTS.
 If you get stuck or need help, head to our [community](https://help.replicated.com/community/).
 
-This guide will deploy a basic application using KOTS, and show you how to deliver an update to that application. 
+This guide will deploy a basic application using KOTS, and show you how to deliver an update to that application.
 The guide isn't going to teach Kubernetes, rather it will start with a minimal Kubernetes application that deploys a single replica of [nginx](https://www.nginx.com).
 
 ### Create a New Application
 
-To start, log in (or create a new team) on [vendor.replicated.com](https://vendor.replicated.com) and create a new application. 
-After signing up and activating your account, you will be prompted to create a new application. 
+To start, log in (or create a new team) on [vendor.replicated.com](https://vendor.replicated.com) and create a new application.
+After signing up and activating your account, you will be prompted to create a new application.
 Give it a name like "Starter KOTS application" or "Nginx Example" and click the "Create Application" button.
 
 ![Create Application](/images/guides/kots/create-application.png)
 
 ### Releases
 
-You should be at the channels page now. 
-This is a list of your release channels, which are logical stacks for you to stage and promote releases to your customers. 
-We'll explore this in more detail later. 
+You should be at the channels page now.
+This is a list of your release channels, which are logical stacks for you to stage and promote releases to your customers.
+We'll explore this in more detail later.
 For now, click on the "Releases" item on the left menu and then click the "Create a release" button.
 
 ![Create Release](/images/guides/kots/create-release.png)
 
 ### Create a Release
 
-You should now see a YAML editor where you can define how your application will work and the integration with KOTS functionality. 
+You should now see a YAML editor where you can define how your application will work and the integration with KOTS functionality.
 Once you are familiar with these concepts, you'll probably use our [CLI and API](/vendor/cli) to automate this rather than manually edit YAML on this page (although if you're itching to hit the command line, rather than editing YAML in the browser, you can always run through the [CLI setup guide](/vendor/guides/cli-quickstart/#2-setting-an-api-token) before coming back to complete this guide).
 
 {{< notes title="Quickstart" >}}
-Since this guide is intended as a "Hello, World" example, we'll skip editing the YAML right now and just proceed with the defaults. 
+Since this guide is intended as a "Hello, World" example, we'll skip editing the YAML right now and just proceed with the defaults.
 We'll make some changes later on in this guide.
 {{< /notes >}}
 
 ![Default YAML](/images/guides/kots/default-yaml.png)
 
-The default YAML documents above the white line contains information for KOTS, preflight checks, customer configuration screen options, and support bundle analyzers for troubleshooting installs. 
+The default YAML documents above the white line contains information for KOTS, preflight checks, customer configuration screen options, and support bundle analyzers for troubleshooting installs.
 You can learn about those [in the reference docs](/reference/v1beta1) but for now, let's click the "Save release" button in the bottom right.
 
 ### Save and Promote Release
 
-Once the release is saved, go ahead and promote it to the "Unstable" channel to make this release available for installation. 
-To do this, click the "Releases" link in the top left and then click the "Promote" button on the row we just created. 
+Once the release is saved, go ahead and promote it to the "Unstable" channel to make this release available for installation.
+To do this, click the "Releases" link in the top left and then click the "Promote" button on the row we just created.
 In this popup, choose the "Unstable" channel and click the "Promote" button.
 
 ![Create Application](/images/guides/kots/promote-release.png)
@@ -70,32 +70,32 @@ Now that we've got a release promoted, we can walk through creating a license an
 
 ## Installing and Testing
 
-This guide will give you first-hand experience installing a KOTS application using an existing Kubernetes cluster. 
+This guide will give you first-hand experience installing a KOTS application using an existing Kubernetes cluster.
 If you haven't yet created a release, head back to the [Create and Promote a Release](#creating-a-release) guide and complete that first.
 
 Now that we've created a release and promoted it to the "Unstable" channel, the next step is to create a customer license and use this license to install the application in a namespace in our test cluster.
 
 ### Create License
 
-A customer license (downloadable as a `.yaml` file) is required to install any KOTS application. 
-To create a customer license, log in to the [Vendor Portal](https://vendor.replicated.com) and select the Customers link on the left. 
+A customer license (downloadable as a `.yaml` file) is required to install any KOTS application.
+To create a customer license, log in to the [Vendor Portal](https://vendor.replicated.com) and select the Customers link on the left.
 Click the "Create your first customer" button to continue.
 
 ![Customers](/images/guides/kots/customers.png)
 
-On the "Create a new customer" page, fill in your name for the "Customer name" field, select the "Unstable" channel on the right hand side, and click "Save Changes". 
+On the "Create a new customer" page, fill in your name for the "Customer name" field, select the "Unstable" channel on the right hand side, and click "Save Changes".
 The defaults in all other fields will be fine.
 
 ![Create Customer](/images/guides/kots/create-customer.png)
 
-After creating the customer, click the "Download license" link in the upper right corner. 
-This will download the file with your customer name and a `.yaml` extension. 
-This is the license file your customer will need to install your application. 
+After creating the customer, click the "Download license" link in the upper right corner.
+This will download the file with your customer name and a `.yaml` extension.
+This is the license file your customer will need to install your application.
 When a customer is installing your software you need to send them two things: the KOTS install script and the license file.
 
 ### Create Kubernetes Cluster and Install KOTS
 
-KOTS can be installed either into an existing Kubernetes cluster, or as an embedded cluster. 
+KOTS can be installed either into an existing Kubernetes cluster, or as an embedded cluster.
 You can see the installation options at the bottom of each channel on the Channels page.
 
 ![Installation Methods](/images/guides/kots/installation-methods-existing.png)
@@ -136,37 +136,37 @@ Enter a new password to be used for the Admin Console: ••••••••
 
 ### Install License
 
-At this point, the Admin Console and Kubernetes are running, but the application isn't yet. 
-This is also what your customer would be experiencing when installing your application. 
+At this point, the Admin Console and Kubernetes are running, but the application isn't yet.
+This is also what your customer would be experiencing when installing your application.
 To complete the installation, visit the URL `http://localhost:8800` where you'll be required to enter the password set earlier.
 
 ![Console TLS](/images/guides/kots/admin-console-login.png)
 
-Now the installation needs a license file to continue. 
-Until this point, this cluster is just running Kubernetes and the Admin Console containers. 
-Once we upload a license file, kotsadm will have access to pull the application YAML and containers. 
+Now the installation needs a license file to continue.
+Until this point, this cluster is just running Kubernetes and the Admin Console containers.
+Once we upload a license file, kotsadm will have access to pull the application YAML and containers.
 Click the Upload button and select your `.yaml` file to continue.
 
 ![Upload License](/images/guides/kots/upload-license.png)
 
-The settings page is here with default configuration items. 
-The appearance of this page can be configured in the `config.yaml` file. 
+The settings page is here with default configuration items.
+The appearance of this page can be configured in the `config.yaml` file.
 For now we can proceed with the defaults.
 
 ![Settings Page](/images/guides/kots/configuration.png)
 
-Preflight checks are designed to ensure this server has the minimum system and software requirements to run the application. 
-By default, we include some preflight checks that are expected to fail so that we can see what failing checks might look like for a customer. 
+Preflight checks are designed to ensure this server has the minimum system and software requirements to run the application.
+By default, we include some preflight checks that are expected to fail so that we can see what failing checks might look like for a customer.
 If you click continue it will warn you but you can still continue.
 
 ![Preflight Checks](/images/guides/kots/preflight.png)
 
-Click the "Application" link on the top to see the application running. 
+Click the "Application" link on the top to see the application running.
 If you are still connected to this server over ssh, `kubectl get pods` will now show the example nginx service we just deployed.
 
 ![Dashboard](/images/guides/kots/dashboard.png)
 
-On the nav bar, there's a link to the application page. 
+On the nav bar, there's a link to the application page.
 Clicking that will show you the Kubernetes services that we just deployed.
 
 ![Cluster](/images/guides/kots/application.png)
@@ -190,51 +190,62 @@ Next, we'll walk through creating and delivering an update to the application we
 
 ## Iterating and Updating
 
-This guide will walk you through making a change and delivering an update to an application after it's been deployed. 
-It's assumed you have the environment from parts 1 and 2 of this guide ([creating a release](#creating-a-release) and [installing](#installing-and-testing)). 
+This guide will walk you through making a change and delivering an update to an application after it's been deployed.
+It's assumed you have the environment from parts 1 and 2 of this guide ([creating a release](#creating-a-release) and [installing](#installing-and-testing)).
 If you haven't completed these guides, head back and finish them first.
 
-Now that we have a KOTS application running, a common task is to deliver updates. 
+Now that we have a KOTS application running, a common task is to deliver updates.
 Let's change the number of nginx replicas to show how to deliver an update.
 
 ### Create a New Release
 
-On the Releases page of the [Vendor Portal](https://vendor.replicated.com), click the "Create Release" link on top. 
-Once again, you'll be taken to a YAML editor that shows the contents of the most recently created release. 
+On the "Releases" page of the [Vendor Portal](https://vendor.replicated.com), click the "Create Release" link on top.
+Once again, you'll be taken to a YAML editor that shows the contents of the most recently created release.
 This gives us everything we've done so far, and our task now is to only write the changes needed to increase the number of nginx replicas.
 
-In the release YAML, find the nginx image to change. 
-The line is in the `deployment.yaml` file and looks like:
+We'll add a line to `deployment.yaml`, right after `spec:`.
+The line to add is
 
 ```yaml
-replicas: 1
+  replicas: 2
 ```
 
-Change the number to `2` or more.
+The first few lines of your file should now look like
 
-**Note**: If you've worked ahead and already completed the [CLI setup guide](/vendor/guides/cli-quickstart), you can make this `replicas` change in your locally checked-out git repo, and publish them with `replicated release create --auto`, then skip to [Update the Test Server](#update-the-test-server).
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-nginx
+  labels:
+    app: example
+    component: nginx
+spec:
+  replicas: 2
+  selector:
+```
 
 ### Save and Promote the Release
 
-Following the same process we did before, click the "Save Release" button, go back one screen and click "Promote" next to the newly created Sequence 2. 
-Choose the "Unstable" channel again to promote this new release. 
+Following the same process we did before, click the "Save Release" button, go back one screen and click "Promote" next to the newly created Sequence 2.
+Choose the "Unstable" channel again to promote this new release.
 Now, any license installed from the "Unstable" channel will start with this new release, and any installation already running will be prompted to update to the new release.
 
 ### Update the Test Server
 
-To install and test this new release, we need to connect to the Admin Console dashboard on port :8800 using a web browser. 
-At this point, it will likely show that our test application is "Up To Date" and that "No Updates Are Available". 
+To install and test this new release, we need to connect to the Admin Console dashboard on port :8800 using a web browser.
+At this point, it will likely show that our test application is "Up To Date" and that "No Updates Are Available".
 The Admin Console will check for new updates about every five hours but we can force it to check now.
 
-In the "Application" or "Version History" tab click on the "Check For Updates" button. 
-On the version history page the faded "Deployed" button should become active and say "Deploy." 
-In addition, it should say how many files were changed and how many lines are different. 
+In the "Application" or "Version History" tab click on the "Check For Updates" button.
+On the version history page the faded "Deployed" button should become active and say "Deploy."
+In addition, it should say how many files were changed and how many lines are different.
 You can click on that to view what has changed in the yaml.
 
 
 ![View Update](/images/guides/kots/view-update.png)
 
-Clicking the "Deploy" button will apply the new YAML which will change the number of nginx replicas. 
+Clicking the "Deploy" button will apply the new YAML which will change the number of nginx replicas.
 This should only take a few seconds to deploy.
 
 * * *

--- a/content/vendor/guides/quickstart.md
+++ b/content/vendor/guides/quickstart.md
@@ -46,8 +46,8 @@ For now, click on the Releases item on the left menu and then click the "Create 
 
 ### Create a Release
 
-You should now see a YAML editor where you can define how you application will work and the integration with KOTS functionality. 
-Once you are familiar with these concepts, you'll probably use our [CLI and API](/vendor/cli) to automate this rather than manually edit YAML on this page. 
+You should now see a YAML editor where you can define how you application will work and the integration with KOTS functionality.
+Once you are familiar with these concepts, you'll probably use our [CLI and API](/vendor/cli) to automate this rather than manually edit YAML on this page.
 If you're itching to hit the command line rather than editing YAML in the browser, you can always switch gears and follow our  [CLI Quickstart guide](/vendor/guides/cli-quickstart).
 
 {{< notes title="Quickstart" >}}
@@ -227,14 +227,27 @@ On the "Releases" page of the [Vendor Portal](https://vendor.replicated.com), cl
 Once again, you'll be taken to a YAML editor that shows the contents of the most recently created release.
 This gives us everything we've done so far, and our task now is to only write the changes needed to increase the number of nginx replicas.
 
-In the release YAML, find the nginx image to change.
-The line is in the `deployment.yaml` file and looks like:
+We'll add a line to `deployment.yaml`, right after `spec:`.
+The line to add is
 
 ```yaml
-replicas: 1
+  replicas: 2
 ```
 
-Change the number to `2` or more.
+The first few lines of your file should now look like
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-nginx
+  labels:
+    app: example
+    component: nginx
+spec:
+  replicas: 2
+  selector:
+```
 
 **Note**: If you've worked ahead and already completed the [CLI setup guide](/vendor/guides/cli-quickstart), you can make this `replicas` change in your locally checked-out git repo, and publish them with `replicated release create --auto`, then skip to [Update the Test Server](#update-the-test-server).
 


### PR DESCRIPTION
The default YAML no longer includes the replicas: 1 line in it, because
that was triggering a linter warning. I've updated the guide to handle that better