### PR TITLE
clarify embedded support in 1.25.0

### DIFF
--- a/content/release-notes/1.25.0.md
+++ b/content/release-notes/1.25.0.md
@@ -6,7 +6,7 @@ kubernetes: "1.17, 1.18, and 1.19"
 ---
 
 {{<features>}}
-* Added the ability to control access to the KOTS Admin Console by integrating with an identity provider. This feature is experimental and only available to vendors and licenses that have the [Identity Service](https://kots.io/kotsadm/access/securing-the-console/) feature enabled.
+* Added the ability to control access to the KOTS Admin Console by integrating with an identity provider. This feature is experimental and only available to vendors and licenses that have the [Identity Service](https://kots.io/kotsadm/access/securing-the-console/) feature enabled. It is currently only available for the embedded Kubernetes installation method. 
 * Added the ability to redeploy the currently deployed app version.
 * Added beta support for instance snapshots in embedded clusters.
 {{</features>}}


### PR DESCRIPTION
clarify embedded support only now vs existing cluster