### PR TITLE
clarify embedded support in 1.26.0

### DIFF
--- a/content/release-notes/1.26.0.md
+++ b/content/release-notes/1.26.0.md
@@ -6,7 +6,7 @@ kubernetes: "1.17, 1.18, and 1.19"
 ---
 
 {{<features>}}
-* Added the ability to control access to the Vendor Application by integrating with an identity provider. This feature is experimental and only available to vendors and licenses that have the [Identity Service](https://kots.io/vendor/identity-service/configuring-identity-service/) feature enabled.
+* Added the ability to control access to the Vendor Application by integrating with an identity provider. This feature is experimental and only available to vendors and licenses that have the [Identity Service](https://kots.io/vendor/identity-service/configuring-identity-service/) feature enabled. It is currently only available for the embedded Kubernetes installation method. 
 {{</features>}}
 
 {{<changes>}}


### PR DESCRIPTION
clarify embedded support only now vs existing cluster