### PR TITLE
make k8s version compatibility chart more scalable

### DIFF
--- a/content/kotsadm/installing/system-requirements.md
+++ b/content/kotsadm/installing/system-requirements.md
@@ -11,21 +11,14 @@ The requirements for command-line-interfaces (such as the [Vendor CLI](/vendor/c
 
 ## Kubernetes Version Compatibility
 
-Each release of KOTS maintains compatability with the current Kubernetes version, and the 2 most recent versions.
+Each release of KOTS maintains compatability with the current Kubernetes version, and the 2 most recent versions at the time of its release.
 This includes support against all patch releases of the corrersponding Kubernetes version.
 
-| KOTS Version | Release Date | Kubernetes Compatibility |
-|------|------------|-------------|
-| 1.11 | 2020-01-22 | 1.17, 1.16, and 1.15 |
-| 1.12 | 2020-02-04 | 1.17, 1.16, and 1.15 |
-| 1.13 | 2020-02-27 | 1.17, 1.16, and 1.15 |
-| 1.14 | 2020-03-31 | 1.17, 1.16, and 1.15 |
-| 1.15 | 2020-05-01 | 1.18, 1.17, and 1.16 |
-| 1.16 | 2020-06-01 | 1.18, 1.17, and 1.16 |
-| 1.17 | 2020-07-14 | 1.18, 1.17, and 1.16 |
-| 1.18 | 2020-08-10 | 1.18, 1.17, and 1.16 |
-| 1.19 | 2020-09-11 | 1.18, 1.17, and 1.16 |
-| 1.20 | 2020-10-09 | 1.19, 1.18, and 1.17 |
+| KOTS Version(s) | Kubernetes Compatibility |
+|-----------------|-------------|
+| 1.11 to 1.14 | 1.17, 1.16, and 1.15 |
+| 1.15 to 1.19 | 1.18, 1.17, and 1.16 |
+| 1.20+ | 1.19, 1.18, and 1.17 |
 
 ## Existing Cluster Installation Requirements
 


### PR DESCRIPTION
Looking at the docs, we hadn't updated this chart since the v1.20 release. Adding a line with each release makes it easy to get outdated, and it gets really long if we release frequently. I updated to a format that still conveys the info, but should be easier to maintain while taking up less content area.