### PR TITLE
update KOTS install command

### DIFF
--- a/content/kotsadm/installing/airgap-packages.md
+++ b/content/kotsadm/installing/airgap-packages.md
@@ -37,8 +37,7 @@ These credentials will be used to pull the images, and will be automatically cre
 
 ```shell
 kubectl kots install app-name \
-  --kotsadm-namespace app-name \
-  --kotsadm-registry private.registry.host \
+  --kotsadm-registry private.registry.host/app-name \
   --registry-username ro-username \
   --registry-password ro-password
 ```


### PR DESCRIPTION
Doc location: https://kots.io/kotsadm/installing/airgap-packages/#kots-install

Removed `--kotsadm-namespace app-name` as it is not in the latest [install video](https://www.youtube.com/watch?v=OLjwKSuRCXM) ~and it prompts for the namespace to deploy to once the command is run~.

Added `/app-name` to the end of ` --kotsadm-registry private.registry.host` to match previous push to registry command.