### PR TITLE
Fix helm pull command

### DIFF
--- a/content/kots-cli/install.md
+++ b/content/kots-cli/install.md
@@ -55,4 +55,4 @@ kubectl kots install kots-sentry/stable --shared-password IgqG5OBc9Gp --license-
 ```
 
 <!-- Helm example coming soon -->
-<!-- kubectl kots install helm://stable/elasticsearch -->
+<!-- kubectl kots install helm://elastic/elasticsearch -->

--- a/content/kots-cli/pull.md
+++ b/content/kots-cli/pull.md
@@ -5,7 +5,7 @@ title: kots pull
 weight: 90110
 ---
 
-If you’d rather use kubectl or another workflow to deploy to your cluster, you can run `kots pull` to create a directory on your workstation with the KOTS application and the Kubernetes manifests. 
+If you’d rather use kubectl or another workflow to deploy to your cluster, you can run `kots pull` to create a directory on your workstation with the KOTS application and the Kubernetes manifests.
 This workflow is necessary when managing a KOTS application without the use of the Admin Console.
 
 ### Usage
@@ -45,5 +45,5 @@ This command supports all [global flags](/kots-cli/global-flags/) and also:
 ### Example
 ```bash
 kubectl kots pull sentry/unstable --license-file ~/license.yaml
-kubectl kots pull helm://stable/elasticsearch --helm-version v3
+kubectl kots pull helm://elastic/elasticsearch --helm-version v3
 ```

--- a/content/kotsadm/installing/helm-chart.md
+++ b/content/kotsadm/installing/helm-chart.md
@@ -21,13 +21,13 @@ To start, first [install the Kots CLI kubectl plugin](/kots-cli/getting-started/
 In the example, we'll use the `elasticsearch` chart from the `stable` helm repository.
 
 ```shell
-kubectl kots install helm://stable/elasticsearch
+kubectl kots install helm://elastic/elasticsearch
 ```
 
 The kubectl plugin will walk you through the necessary steps to install the application:
 
 ```shell
-$ kubectl kots install helm://stable/elasticsearch
+$ kubectl kots install helm://elastic/elasticsearch
 Enter the namespace to deploy to: elasticsearch
 
   • Pulling upstream ✓


### PR DESCRIPTION
```
~$ kubectl kots pull helm://elastic/elasticsearch --helm-version v3

  • Pulling upstream ✓  
  • Creating base ✓  
  • Creating midstream ✓  

    Kubernetes application files created in /home/user/elasticsearch

    To deploy, run kubectl apply -k /home/user/elasticsearch/overlays/midstream
```