### PR TITLE
document generate-manifests command

### DIFF
--- a/content/kots-cli/admin-console/generate-manifests.md
+++ b/content/kots-cli/admin-console/generate-manifests.md
@@ -5,13 +5,14 @@ title: kots admin-console generate-manifests
 weight: 90130
 ---
 
-If you’d rather use kubectl or another workflow to deploy to a cluster, run `kots admin-console generate-manifests` to create a directory on the workstation containing the KOTS Admin Console manifests. This workflow enables additional customization of the Admin Console before deploying.
+Running this command will create a directory on the workstation containing the KOTS Admin Console manifests. These assets can be used to deploy KOTS to a cluster through other workflows, such as kubectl, to provide additional customization of the Admin Console before deploying.
 
 ### Usage
 ```bash
 kubectl kots admin-console generate-manifests [flags]
 ```
-* _Provide `[flags]` according to the table below_
+
+This command supports the following flags:
 
 | Flag | Type | Description |
 |:-----|------|-------------|

--- a/content/kots-cli/admin-console/generate-manifests.md
+++ b/content/kots-cli/admin-console/generate-manifests.md
@@ -2,7 +2,7 @@
 date: 2021-07-29
 linktitle: "generate-manifests"
 title: kots admin-console generate-manifests
-weight: 90110
+weight: 90130
 ---
 
 If you’d rather use kubectl or another workflow to deploy to a cluster, run `kots admin-console generate-manifests` to create a directory on the workstation containing the KOTS Admin Console manifests. This workflow enables additional customization of the Admin Console before deploying.

--- a/content/kots-cli/admin-console/generate-manifests.md
+++ b/content/kots-cli/admin-console/generate-manifests.md
@@ -1,0 +1,29 @@
+---
+date: 2021-07-29
+linktitle: "generate-manifests"
+title: kots admin-console generate-manifests
+weight: 90110
+---
+
+If you’d rather use kubectl or another workflow to deploy to a cluster, run `kots admin-console generate-manifests` to create a directory on the workstation containing the KOTS Admin Console manifests. This workflow enables additional customization of the Admin Console before deploying.
+
+### Usage
+```bash
+kubectl kots admin-console generate-manifests [flags]
+```
+* _Provide `[flags]` according to the table below_
+
+| Flag | Type | Description |
+|:-----|------|-------------|
+| `--rootdir` | string | root directory where the yaml will be written _(default `${HOME}` or `%USERPROFILE%`)_ |
+| `--shared-password` | string | shared password to use when deploying the admin console |
+| `--http-proxy` | string | sets HTTP_PROXY environment variable in all KOTS Admin Console components |
+| `--https-proxy` | string | sets HTTPS_PROXY environment variable in all KOTS Admin Console components |
+| `--no-proxy` | string | sets NO_PROXY environment variable in all KOTS Admin Console components |
+| `--with-minio` | bool | set to true to include a local minio instance to be used for storage _(default true)_ |
+
+### Examples
+```bash
+kubectl kots admin-console generate-manifests
+kubectl kots admin-console generate-manifests --rootdir ./manifests
+```


### PR DESCRIPTION
[CH36021](https://app.clubhouse.io/replicated/story/36021/a-cli-command-or-a-flag-for-the-kots-pull-command-to-generate-only-the-admin-console-components-as-kustomizable-yaml-manifests)