### PR TITLE
update kots pull to match contribution guidelines

### DIFF
--- a/content/kots-cli/pull.md
+++ b/content/kots-cli/pull.md
@@ -5,8 +5,7 @@ title: kots pull
 weight: 90110
 ---
 
-If you’d rather use kubectl or another workflow to deploy to your cluster, you can run `kots pull` to create a directory on your workstation with the KOTS application and the Kubernetes manifests.
-This workflow is necessary when managing a KOTS application without the use of the Admin Console.
+Running this command will create a directory on the workstation containing the KOTS application and Kubernetes manifests. These assets can be used to deploy KOTS to a cluster through other workflows, such as kubectl. This command is necessary when managing a KOTS application without the use of the Admin Console.
 
 ### Usage
 ```bash
@@ -18,32 +17,31 @@ kubectl kots pull [upstream uri] [flags]
 
 This command supports all [global flags](/kots-cli/global-flags/) and also:
 
+| Flag | Type | Description |
+|:-----|------|-------------|
+| `--downstream` | strings | the list of any downstreams to create/update |
+| `--exclude-admin-console` | bool | set to true to exclude the admin console _(only valid when `[upstream-uri]` points to a replicated app)_ |
+| `--exclude-kots-kinds` | bool | set to true to exclude rendering KOTS custom objects to the base directory _(default `true`)_ |
+| `-h, --help` | | help for pull |
+| `--helm-version` | string | the Helm version with which to render the Helm Chart _(default `"v2"`)_. This is a beta feature |
+| `--image-namespace` | string | the namespace/org in the docker registry to push images to _(required when `--rewrite-images` is set)_ |
+| `--license-file` | string | path to a license file _(required when `[upstream-uri]` points to a replicated app)_ |
+| `--local-path` | string | specify a local-path to pull a locally available replicated app _(only valid when `[upstream-uri]` points to a replicated app)_ |
+| `-n, --namespace` | string | namespace to render the upstream to in the base _(default `"default"`)_ |
+| `--registry-endpoint` | string | the endpoint of the local docker registry to use when pushing images _(required when `--rewrite-images` is set)_ |
+| `--repo` | string | repo uri to use when downloading a helm chart |
+| `--rewrite-images` | bool | set to true to force all container images to be rewritten and pushed to a local registry |
+| `--rootdir` | string | root directory that will be used to write the yaml to _(default `${HOME}` or `%USERPROFILE%`)_ |
+| `--set` | strings | values to pass to helm when running helm template |
+| `--shared-password` | string | shared password to use when deploying the admin console |
+| `--http-proxy` | string | sets HTTP_PROXY environment variable in all KOTS Admin Console components |
+| `--https-proxy` | string | sets HTTPS_PROXY environment variable in all KOTS Admin Console components |
+| `--no-proxy` | string | sets NO_PROXY environment variable in all KOTS Admin Console components |
+| `--copy-proxy-env` | bool | copy proxy environment variables from current environment into all KOTS Admin Console components |
+| `--config-values` | string | path to a manifest containing config values (must be apiVersion: kots.io/v1beta1, kind: ConfigValues) |
+| `--with-minio` | bool | set to true to include a local minio instance to be used for storage _(default true)_ |
 
-| Flag                      | Type    | Description                                                                                                                     |
-|:--------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------|
-| `--downstream`            | strings | the list of any downstreams to create/update                                                                                    |
-| `--exclude-admin-console` | bool    | set to true to exclude the admin console _(only valid when `[upstream-uri]` points to a replicated app)_                        |
-| `--exclude-kots-kinds`    | bool    | set to true to exclude rendering KOTS custom objects to the base directory _(default `true`)_                                   |
-| `-h, --help`              |         | help for pull                                                                                                                   |
-| `--helm-version`          | string  | the Helm version with which to render the Helm Chart _(default `"v2"`)_. This is a beta feature                                 |
-| `--image-namespace`       | string  | the namespace/org in the docker registry to push images to _(required when `--rewrite-images` is set)_                          |
-| `--license-file`          | string  | path to a license file _(required when `[upstream-uri]` points to a replicated app)_                                            |
-| `--local-path`            | string  | specify a local-path to pull a locally available replicated app _(only valid when `[upstream-uri]` points to a replicated app)_ |
-| `-n, --namespace`         | string  | namespace to render the upstream to in the base _(default `"default"`)_                                                         |
-| `--registry-endpoint`     | string  | the endpoint of the local docker registry to use when pushing images _(required when `--rewrite-images` is set)_                |
-| `--repo`                  | string  | repo uri to use when downloading a helm chart                                                                                   |
-| `--rewrite-images`        | bool    | set to true to force all container images to be rewritten and pushed to a local registry                                        |
-| `--rootdir`               | string  | root directory that will be used to write the yaml to _(default `"/path/"`)_                                                    |
-| `--set`                   | strings | values to pass to helm when running helm template                                                                               |
-| `--shared-password`       | string  | shared password to use when deploying the admin console                                                                         |
-| `--http-proxy`            | string  | sets HTTP_PROXY environment variable in all KOTS Admin Console components                                                       |
-| `--https-proxy`           | string  | sets HTTPS_PROXY environment variable in all KOTS Admin Console components                                                      |
-| `--no-proxy`              | string  | sets NO_PROXY environment variable in all KOTS Admin Console components                                                         |
-| `--copy-proxy-env`        | bool    | copy proxy environment variables from current environment into all KOTS Admin Console components                                |
-| `--config-values`         | string  | path to a manifest containing config values (must be apiVersion: kots.io/v1beta1, kind: ConfigValues)                           |
-| `--with-minio`            | bool    | set to true to include a local minio instance to be used for storage _(default true)_                                           |
-
-### Example
+### Examples
 ```bash
 kubectl kots pull sentry/unstable --license-file ~/license.yaml
 kubectl kots pull helm://elastic/elasticsearch --helm-version v3


### PR DESCRIPTION
I used this one as a template for `kots admin-console generate-manifests` and noticed it didn't follow our contribution guidelines.