### PR TITLE
[1.50.0] docs: add output flag to relevant cli cmds

### DIFF
--- a/content/kots-cli/backup/_index.md
+++ b/content/kots-cli/backup/_index.md
@@ -15,10 +15,11 @@ kubectl kots backup [flags]
 
 - _Provide `[flags]` according to the table below_
 
-| Flag              | Type   | Description                                                              |
-| :---------------- | ------ | ------------------------------------------------------------------------ |
-| `-h, --help`      |        | help for backup                                                          |
-| `-n, --namespace` | string | the namespace where the admin console is running _(default `"default"`)_ |
+| Flag              | Type   | Description                                                                     |
+| :---------------- | ------ | ------------------------------------------------------------------------------- |
+| `-h, --help`      |        | help for backup                                                                 |
+| `-n, --namespace` | string | the namespace where the admin console is running _(default `"default"`)_        |
+| `-o, --output`    | string | output format (currently supported: json) _(defaults to plain text if not set)_ |
 
 ### Example
 

--- a/content/kots-cli/download.md
+++ b/content/kots-cli/download.md
@@ -22,10 +22,11 @@ This command supports all [global flags](/kots-cli/global-flags/) and also:
 | Flag                 | Type | Description |
 |:----------------------|------|-------------|
 | `--decrypt-password-values` | bool | decrypt password values to plaintext |
-| `--dest` | string |        the directory to store the application in _(defaults to current working dir)_ |
-| `-h, --help`   |  |           help for download |
-| `-n, --namespace` | string |    the namespace to download from _(default `"default"`)_ |
-| `--overwrite` |   |       overwrite any local files, if present |
+| `--dest` | string | the directory to store the application in _(defaults to current working dir)_ |
+| `-h, --help` | | help for download |
+| `-n, --namespace` | string | the namespace to download from _(default `"default"`)_ |
+| `--overwrite` | | overwrite any local files, if present |
+| `-o, --output` | string | output format (currently supported: json) _(defaults to plain text if not set)_ |
 
 ### Example
 ```bash

--- a/content/kots-cli/restore/_index.md
+++ b/content/kots-cli/restore/_index.md
@@ -15,10 +15,11 @@ kubectl kots restore [flags]
 
 - _Provide `[flags]` according to the table below_
 
-| Flag            | Type   | Description                                         |
-| :-------------- | ------ | --------------------------------------------------- |
-| `-h, --help`    |        | help for restore                                    |
-| `--from-backup` | string | the name of the backup to restore from _(required)_ |
+| Flag              | Type   | Description                                                                     |
+| :---------------- | ------ | ------------------------------------------------------------------------------- |
+| `-h, --help`      |        | help for restore                                                                |
+| `--from-backup`   | string | the name of the backup to restore from _(required)_                             |
+| `-o, --output`    | string | output format (currently supported: json) _(defaults to plain text if not set)_ |
 
 ### Example
 

--- a/content/kots-cli/upload.md
+++ b/content/kots-cli/upload.md
@@ -27,6 +27,7 @@ This command supports all [global flags](/kots-cli/global-flags/) and also:
 | `--upstream-uri`| string |  the upstream uri that can be used to check for updates |
 | `--deploy`| bool |  when set, automatically deploy the uploaded version |
 | `--skip-preflights`| bool |  set to true to skip preflight checks |
+| `-o, --output` | string | output format (currently supported: json) _(defaults to plain text if not set)_ |
 
 
 Note: Any `plainText` values in the `upstream/userdata/config.yaml` file will be re-encrypted using the application cipher automatically, if the matching config item is a password type.

--- a/content/kots-cli/upstream.md
+++ b/content/kots-cli/upstream.md
@@ -28,6 +28,7 @@ kubectl kots upstream upgrade [app-slug] [flags]
 | `--registry-password`    | string | the password to use to authenticate with the registry                                            |
 | `--registry-username`    | string | the username to use to authenticate with the registry                                            |
 | `--disable-image-push`   | bool   | set to true to disable images from being pushed to private registry                              |
+| `-o, --output`           | string | output format (currently supported: json) _(defaults to plain text if not set)_                  |
 
 ### Example
 ```bash


### PR DESCRIPTION
[CH33701](https://app.clubhouse.io/replicated/story/33701/kots-cli-add-output-formatting-option-for-json-and-status-field-if-possible)