### PR TITLE
updating token docs

### DIFF
--- a/content/vendor/cli/getting-started.md
+++ b/content/vendor/cli/getting-started.md
@@ -25,7 +25,7 @@ You’ll need to set up two environment variables to interact with https://vendo
 * `REPLICATED_APP` should be set to the name of your KOTS application, as shown in the URL path at https://vendor.replicated.com/apps. _Note that this is **case sensitive**_
 ![Vendor Application Slug](/images/vendor-app-slug.png)
 
-* `REPLICATED_API_TOKEN` should be set to a token created at either https://vendor.replicated.com/team/tokens for a team token, or https://vendor.replicated.com/account-settings for a user token.
+* `REPLICATED_API_TOKEN` should be set to a token created at https://vendor.replicated.com/team/tokens.
 ![Vendor API Token](/images/vendor-team-token.png)
 
 Ensure the token has “Write” access or you’ll be unable create new releases. 

--- a/content/vendor/cli/tokens.md
+++ b/content/vendor/cli/tokens.md
@@ -27,7 +27,7 @@ Team tokens can be set to Read Only or Read / Write.
 
 ## User Tokens
 
-User tokens should be used for REST API authorization.
+User tokens should be used for [REST API](https://help.replicated.com/api/vendor-api/) authorization.
 
 User tokens are private to the user creating the token. User tokens assume the user's account when used, including RBAC permissions.
 

--- a/content/vendor/cli/tokens.md
+++ b/content/vendor/cli/tokens.md
@@ -15,19 +15,19 @@ Tokens may only access a portion of the Vendor API. The following administrative
 - Managing integrations
 - Managing user tokens
 
-Tokens are primarily used with vendor CLI commands for automated customer, channel, and release management.
+Tokens are primarily used with Vendor CLI or REST API commands for automated customer, channel, and release management.
 
 ## Team Tokens
 
-Team tokens should be used for [Vendor CLI](https://help.replicated.com/api/replicated-vendor-cli/) authorization.
+Team tokens are used for [Vendor CLI](https://help.replicated.com/api/replicated-vendor-cli/) authorization.
 
 Team tokens are available to all members of the vendor team. These tokens can be created, retrieved, and revoked by any user with the proper RBAC policy.
 
-Team tokens can be set to Read Only or Read / Write.
+Team tokens can be set to Read Only or Read / Write privileges.
 
 ## User Tokens
 
-User tokens should be used for [REST API](https://help.replicated.com/api/vendor-api/) authorization.
+User tokens are used for [REST API](https://help.replicated.com/api/vendor-api/) authorization.
 
 User tokens are private to the user creating the token. User tokens assume the user's account when used, including RBAC permissions.
 

--- a/content/vendor/cli/tokens.md
+++ b/content/vendor/cli/tokens.md
@@ -19,7 +19,7 @@ Tokens are primarily used with vendor CLI commands for automated customer, chann
 
 ## Team Tokens
 
-Team tokens should be used for CLI authorization.
+Team tokens should be used for [Vendor CLI](https://help.replicated.com/api/replicated-vendor-cli/) authorization.
 
 Team tokens are available to all members of the vendor team. These tokens can be created, retrieved, and revoked by any user with the proper RBAC policy.
 

--- a/content/vendor/cli/tokens.md
+++ b/content/vendor/cli/tokens.md
@@ -6,7 +6,7 @@ weight: 90105
 draft: false
 ---
 
-Using the Vendor CLI requires a token for authentication.  Replicated supports two types of tokens: Team Tokens and User Tokens.
+Using the Vendor CLI and REST API requires a token for authorization.  Replicated supports two types of tokens: Team Tokens and User Tokens.
 
 Tokens may only access a portion of the Vendor API. The following administrative tasks cannot be performed with token authentication and can only be executed by a logged-in user: 
 - Managing team members
@@ -19,11 +19,15 @@ Tokens are primarily used with vendor CLI commands for automated customer, chann
 
 ## Team Tokens
 
+Team tokens should be used for CLI authorization.
+
 Team tokens are available to all members of the vendor team. These tokens can be created, retrieved, and revoked by any user with the proper RBAC policy.
 
 Team tokens can be set to Read Only or Read / Write.
 
 ## User Tokens
+
+User tokens should be used for REST API authorization.
 
 User tokens are private to the user creating the token. User tokens assume the user's account when used, including RBAC permissions.
 


### PR DESCRIPTION
User tokens cannot be used in CLI commands hitting GraphQL.  GraphQL does not enforce any RBAC and will not check for hashed user tokens.