### PR TITLE
Update install.md

### DIFF
--- a/content/kots-cli/install.md
+++ b/content/kots-cli/install.md
@@ -20,7 +20,7 @@ kubectl kots install [upstream uri] [flags]
 
 This command supports all [global flags](/kots-cli/global-flags/) and also:
 
-|  <div style="width:170px">Flag</div>              | Type   | Description                                                                                                                          |
+|  <div style="width:290px">Flag</div>              | Type   | Description                                                                                                                          |
 | :----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `--airgap`              | bool   | set to true to run install in airgapped mode. setting --airgap-bundle implies --airgap=true.                                         |
 | `--airgap-bundle`       | string | path to the application airgap bundle where application metadata will be loaded from                                                 |

--- a/content/kots-cli/install.md
+++ b/content/kots-cli/install.md
@@ -20,10 +20,10 @@ kubectl kots install [upstream uri] [flags]
 
 This command supports all [global flags](/kots-cli/global-flags/) and also:
 
-| Flag                     | Type   | Description                                                                                                                          |
+|  <div style="width:170px">Flag</div>              | Type   | Description                                                                                                                          |
 | :----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `--airgap`               | bool   | set to true to run install in airgapped mode. setting --airgap-bundle implies --airgap=true.                                         |
-| `--airgap-bundle`        | string | path to the application airgap bundle where application metadata will be loaded from                                                 |
+| `--airgap`              | bool   | set to true to run install in airgapped mode. setting --airgap-bundle implies --airgap=true.                                         |
+| `--airgap-bundle`       | string | path to the application airgap bundle where application metadata will be loaded from                                                 |
 | `--config-values`        | string | path to a manifest containing config values (must be apiVersion: kots.io/v1beta1, kind: ConfigValues                                 |
 | `--copy-proxy-env`       | bool   | copy proxy environment variables from current environment into all KOTS Admin Console components                                     |
 | `-h, --help`             |        | help for install                                                                                                                     |

--- a/content/kots-cli/install.md
+++ b/content/kots-cli/install.md
@@ -20,7 +20,7 @@ kubectl kots install [upstream uri] [flags]
 
 This command supports all [global flags](/kots-cli/global-flags/) and also:
 
-|  <div style="width:290px">Flag</div>              | Type   | Description                                                                                                                          |
+|  Flag                    | Type   | Description                                                                                                                          |
 | :----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `--airgap`              | bool   | set to true to run install in airgapped mode. setting --airgap-bundle implies --airgap=true.                                         |
 | `--airgap-bundle`       | string | path to the application airgap bundle where application metadata will be loaded from                                                 |

--- a/themes/hugo-whisper-theme/assets/scss/components/_content.scss
+++ b/themes/hugo-whisper-theme/assets/scss/components/_content.scss
@@ -82,7 +82,7 @@
       background: none;
     }
   }
-  
+
   strong {
     font-weight: bold;
   }
@@ -170,28 +170,28 @@
     display: flex;
     flex-direction: column;
     position: relative;
-  
+
     h1, h2, h3, h4 {
       font-size: 18px !important;
-      line-height: 26px;  
+      line-height: 26px;
       color: #163166;
       display: flex;
       align-items: center;
       margin-bottom: 6px;
       font-weight: bold;
     }
-  
+
     p {
       font-family: Helvetica Neue;
       font-style: normal;
       font-weight: normal;
       font-size: 14px;
-      line-height: 24px;  
+      line-height: 24px;
       color: #163166;
       margin-bottom: 0px;
     }
   }
-  
+
   blockquote::before {
     content: "";
     background-image: url("/images/callout.png");
@@ -204,12 +204,16 @@
     background-size: 26px;
     background-repeat: no-repeat;
   }
-  
+
   table {
     @extend .table;
   }
   img {
     max-width: 100%;
     height: auto;
+  }
+
+  table tr td[align="left"] code {
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
Update the column width to prevent `code` wrapping
https://app.clubhouse.io/replicated/story/32394/kots-io-docs-cli-flags-hard-to-read-due-to-line-splitting