### PR TITLE
fix: clarify ephemeral behavior of ConfigItem defaults

### DIFF
--- a/content/reference/v1beta1/config.md
+++ b/content/reference/v1beta1/config.md
@@ -148,6 +148,8 @@ See the [`ConfigOptionData`](/reference/template-functions/config-context/#confi
 ### `default` and `value`
 A default value will be applied to the ConfigOption template function when no value is specified.
 If default value is not a password field, it will appear as placeholder text in the settings section of the On-Prem Console.
+Default values are treated as ephemeral (the same behavior as the `readonly` property).
+Any config change will re-evaluate any template expression.
 
 A value is data that will be overwritten by user input on non-readonly fields.  
 It will appear as the HTML input value in the settings section of the On-Prem Console.

--- a/content/reference/v1beta1/config.md
+++ b/content/reference/v1beta1/config.md
@@ -148,8 +148,8 @@ See the [`ConfigOptionData`](/reference/template-functions/config-context/#confi
 ### `default` and `value`
 A default value will be applied to the ConfigOption template function when no value is specified.
 If default value is not a password field, it will appear as placeholder text in the settings section of the On-Prem Console.
-Default values are treated as ephemeral (the same behavior as the `readonly` property).
-Any config change will re-evaluate any template expression.
+Default values are treated as ephemeral, which is the same behavior as the `readonly` property.
+Configuration changes will re-evaluate the template expressions.
 
 A value is data that will be overwritten by user input on non-readonly fields.  
 It will appear as the HTML input value in the settings section of the On-Prem Console.

--- a/content/vendor/packaging/template-functions.md
+++ b/content/vendor/packaging/template-functions.md
@@ -105,7 +105,12 @@ The result can be accessed using the [ConfigOption](/reference/template-function
 This example demonstrates how to generate a CA, a cert, and a key using [Sprig](http://masterminds.github.io/sprig/) functions.
 `tls_json` is the hidden config item that contains all of the generated values in JSON format.
 
-Note that this requires KOTS 1.26.0 or later.
+{{< warning title="Important Notes" >}}
+* Notes: that this requires KOTS 1.26.0 or later.
+* Default values are treated as ephemeral. 
+The following certificate chain will be recalculated each time the application config is modified.
+Be sure your application can handle dynamically updating these parameters.
+{{< /warning >}}
 
 ```yaml
 apiVersion: kots.io/v1beta1

--- a/content/vendor/packaging/template-functions.md
+++ b/content/vendor/packaging/template-functions.md
@@ -107,7 +107,7 @@ This example demonstrates how to generate a CA, a cert, and a key using [Sprig](
 
 {{< warning title="Prerequisite" >}}
 * This requires KOTS 1.26.0 or later.
-* Default values are treated as ephemeral. The following certificate chain will be recalculated each time the application config is modified. Be sure your application can handle dynamically updating these parameters.
+* Default values are treated as ephemeral. The following certificate chain is recalculated each time the application configuration is modified. Be sure that your application can handle updating these parameters dynamically.
 {{< /warning >}}
 
 ```yaml

--- a/content/vendor/packaging/template-functions.md
+++ b/content/vendor/packaging/template-functions.md
@@ -105,11 +105,9 @@ The result can be accessed using the [ConfigOption](/reference/template-function
 This example demonstrates how to generate a CA, a cert, and a key using [Sprig](http://masterminds.github.io/sprig/) functions.
 `tls_json` is the hidden config item that contains all of the generated values in JSON format.
 
-{{< warning title="Important Notes" >}}
-* Notes: that this requires KOTS 1.26.0 or later.
-* Default values are treated as ephemeral. 
-The following certificate chain will be recalculated each time the application config is modified.
-Be sure your application can handle dynamically updating these parameters.
+{{< warning title="Prerequisite" >}}
+* This requires KOTS 1.26.0 or later.
+* Default values are treated as ephemeral. The following certificate chain will be recalculated each time the application config is modified. Be sure your application can handle dynamically updating these parameters.
 {{< /warning >}}
 
 ```yaml


### PR DESCRIPTION
Screen cap of the warning box:
![image](https://user-images.githubusercontent.com/12867130/140976330-ba94a264-36e7-4a1d-b626-bacb7c66781a.png)
